### PR TITLE
Serdes: fix integer overflow when computing Serdes protocol map

### DIFF
--- a/Silicon/NXP/Chassis/SerDes.c
+++ b/Silicon/NXP/Chassis/SerDes.c
@@ -147,7 +147,7 @@ LSSerDesMap (
       DEBUG ((DEBUG_ERROR, "Unknown SerDes lane protocol %d\n", LanePrtcl));
       Flag++;
     } else {
-      *SerDesPrtclMap |= BIT (LanePrtcl);
+      *SerDesPrtclMap |= ((UINT64) BIT0 << LanePrtcl);
     }
   }
 
@@ -281,5 +281,5 @@ IsSerDesLaneProtocolConfigured (
     DEBUG ((DEBUG_ERROR, "Unknown SerDes lane protocol Device %d\n", Device));
   }
 
-  return (SerDesPrtclMap & BIT (Device)) != 0 ;
+  return (SerDesPrtclMap & ((UINT64) BIT0 << Device)) != 0 ;
 }


### PR DESCRIPTION
SerDesPrtclMap is a UINT64 but the BIT() macro produces a UINT32, which
was causing SerDesPrtclMap to be filled with incorrect values when using
Serdes protocols numbered greater than 32.

This fixes a hang at boot time when I tried to use UEFI firmware with `SERDES=4_5_2` on my Honeycomb.

The equivalent code in upstream edk2-platforms looks somewhat different but still seems to suffer the same int overflow undefined behaviour. But I'm sending this here first since it's of relevance to Honeycomb users.